### PR TITLE
Hide 'Scan' option for already DRM-Free books

### DIFF
--- a/source/myBooks.js
+++ b/source/myBooks.js
@@ -74,16 +74,12 @@ getSettings(function() {
 				clone.addEventListener("click", function() {
 					t[t.cancelable?"cancel":"start"]();
 				}, false);
-			else if(!this.id) {
+			else {
 				t.inactive = true;
 				clone.addEventListener("click", function() {
 					t.openTab(true);
 				}, false);
 				t.showInactive();
-			}
-			else {
-				clone.href = "#";
-				t.showUnusable();
 			}
 		};
 
@@ -245,15 +241,6 @@ getSettings(function() {
 			this.downloadButton.style.removeProperty("background");
 			this.downloadButton.style.filter = this.downloadButton.style.webkitFilter = "hue-rotate(135deg)";
 			this.text.innerHTML = "Setup Scanner";
-			this.setCancelable(false);
-		},
-		showUnusable: function() {
-			this.downloadButton.style.background = this.buttonBGs.gray;
-			this.downloadButton.style.border = "1px solid #555555";
-			this.downloadButton.style.cursor = "default";
-			this.downloadButton.style.removeProperty("filter");
-			this.downloadButton.style.removeProperty("-webkit-filter");
-			this.text.innerHTML = "Setup Required";
 			this.setCancelable(false);
 		}
 	};


### PR DESCRIPTION
This is in two separate commits because the first commit introduced a problem and the second commit fixes it.

I thought it would be nice to just not show the "Scan" button when books are already DRM-Free, because it's faster to just download the PDF or CBZ already provided. Adding that was relatively simple, however my implementation may be somewhat brittle to DOM changes.

This introduced a problem which is that the "Setup" option would not always display if the first book was DRM-Free. With this change since the "Scannable" books are sprinkled sporadically throughout, at least in my personal comics, I figured that just having ANY "Scan" button start as a "Setup" button made sense. That way any "Scannable" book that I encounter I can use to go through the "setup" process instead of trying to find the first one. This also made the "Unusable" option obsolete, so I removed it.

I'm not sure if this is a desirable feature for anyone else, I just thought it might be nice.
