### PR TITLE
Added update_url to json to avoid corrupted extension message on Chrome 63+

### DIFF
--- a/source/manifest.json
+++ b/source/manifest.json
@@ -44,5 +44,7 @@
 
 	"options_page": "options.html",
 
-	"web_accessible_resources": ["blankLogo.png"]
+	"web_accessible_resources": ["blankLogo.png"],
+
+	"update_url": "https://raw.githubusercontent.com/Cortys/comic-backup/master"
 }


### PR DESCRIPTION
I mentioned this in an issue.  Here's a simple fix